### PR TITLE
Check for idle socket connections at given interval and close them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ The following options are available:
  __exitDelay__       |  Wait timer duration in the final internal callback (triggered either by gracefulExitHandler or the suicideTimeout) if `exitProcess: true`  |  10ms
  __suicideTimeout__  |  How long to wait before giving up on graceful  shutdown, then returns exit code of 1  |  2m 10s (130s)
  __socketio__        |  An instance of `socket.io`, used to close all  open connections after timeout  |  none
- __force__           |  Instructs the module to forcibly close sockets once the suicide timeout elapses. <br> For this option to work you must call `gracefulExit.init(server)` when initializing the HTTP server  |  false
+ __force__           |  Instructs the module to forcibly close sockets once the suicide timeout elapses. <br> For this option to work you must call
+ __idleCheckInterval__   |  Check for for idle sockets and close them at that interval while shutting down | 100ms (.1s)
+ `gracefulExit.init(server)` when initializing the HTTP server  |  false
 
 ## Details
 

--- a/lib/graceful-exit.js
+++ b/lib/graceful-exit.js
@@ -27,7 +27,8 @@ exports.gracefulExitHandler = function(app, server, _options) {
     suicideTimeout    : 2*60*1000 + 10*1000,  // 2m10s (nodejs default is 2m)
     exitProcess       : true,
     exitDelay         : 10,    // wait in ms before process.exit, if exitProcess true
-    force             : false
+    force             : false,
+    idleCheckInterval : 100 // check for idle sockets and close at that interval
   });
   var suicideTimeout;
   var connectionsClosed = false;
@@ -85,6 +86,17 @@ exports.gracefulExitHandler = function(app, server, _options) {
       socket.disconnect();
     });
   }
+
+  // at given interval, check for sockets that have no data buffered and close them if so
+  setInterval(function() {
+    sockets.forEach(function (socket) {
+      if (!socket.bufferSize) {
+        logger('Destroying socket as it is done serving requests');
+        socket.destroy();
+      }
+    });
+  }, options.idleCheckInterval);
+
 
   // If after an acceptable time limit is reached and we still have some
   // connections lingering around for some reason, just die... we tried to


### PR DESCRIPTION
I don't feel ready to merge this yet but I'm curious what you think about the idea @emostar.

We're finding that socket connections created to serve http requests with keep-alive are not closing, even after the request has been served.  The idea here is to check the open sockets at an interval (configureable) and close them if they have no buffered data.  My assumption is that if the server has already stopped accepting new connections, if a connection has no buffered data, that the request has already been served.  Do you agree with that assumption?