### PR TITLE
deprecate socket.io clients method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.4.0 / 2017-03-19
+==================
+
+  * Support disconnect for more socket.io versions
+
 0.3.2 / 2016-08/05
 ==================
 

--- a/lib/graceful-exit.js
+++ b/lib/graceful-exit.js
@@ -82,13 +82,20 @@ exports.gracefulExitHandler = function(app, server, _options) {
   if (options.socketio) {
     var sockets = options.socketio.sockets;
     var connectedSockets;
-    if (typeof sockets.clients === 'function') {
-      logger('Deprecated: socketio.sockets.clients() not supported in next major release');
+    if (typeof sockets.sockets === 'object' && !Array.isArray(sockets.sockets)) {
+      // socket.io 1.4+
+      connectedSockets = _.values(sockets.sockets);
+    }
+    else if (sockets.sockets && sockets.sockets.length) {
+      // socket.io 1.0-1.3
+      connectedSockets = sockets.sockets;
+    }
+    else if (typeof sockets.clients === 'function') {
+      // socket.io 0.x
       connectedSockets = sockets.clients();
     }
-    else if(sockets.sockets) {
-      connectedSockets = _.values(sockets.sockets);
-      options.socketio.close && options.socketio.close();
+    if (typeof options.socketio.close === 'function') {
+      options.socketio.close();
     }
     if (connectedSockets && connectedSockets.length) {
       logger('Killing ' + connectedSockets.length + ' socket.io sockets');

--- a/lib/graceful-exit.js
+++ b/lib/graceful-exit.js
@@ -80,10 +80,22 @@ exports.gracefulExitHandler = function(app, server, _options) {
 
   // Disconnect all the socket.io clients
   if (options.socketio) {
-    options.socketio.sockets.clients().forEach(function(socket) {
-      logger('Killing socketio socket');
-      socket.disconnect();
-    });
+    var sockets = options.socketio.sockets;
+    var connectedSockets;
+    if (typeof sockets.clients === 'function') {
+      logger('Deprecated: socketio.sockets.clients() not supported in next major release');
+      connectedSockets = sockets.clients();
+    }
+    else if(sockets.sockets) {
+      connectedSockets = _.values(sockets.sockets);
+      options.socketio.close && options.socketio.close();
+    }
+    if (connectedSockets && connectedSockets.length) {
+      logger('Killing ' + connectedSockets.length + ' socket.io sockets');
+      connectedSockets.forEach(function(socket) {
+        socket.disconnect();
+      });
+    }
   }
 
   // If after an acceptable time limit is reached and we still have some

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-graceful-exit",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Allow graceful exits for express apps, supporting zero downtime deploys",
   "keywords": [
     "express",


### PR DESCRIPTION
Deprecate `sockets.clients()` for retrieving array of socket objects, and is intended to satisfy the requirements of PR #5 .

This change has not yet been tested in a full fledged application, though compatibility with node versions 0.12 through 7.5 have been performed.  Feedback is welcome.
