### PR TITLE
Add connection close for keep-alive connections

### DIFF
--- a/lib/graceful-exit.js
+++ b/lib/graceful-exit.js
@@ -141,6 +141,7 @@ exports.middleware = function(app) {
   return function(req, res, next) {
     // Sorry Keep-Alive connections, but we need to part ways
     if (app.settings.graceful_exit === true) {
+      res.setHeader('Connection', 'close');
       req.connection.setTimeout(1);
     }
 


### PR DESCRIPTION
From nodejs doc, https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback
When an idle timeout is triggered the socket will receive a 'timeout' event but the connection will not be severed. 

Only setting timeout might be not enough. It would be nice to set `Connection: "close"`  header.