### PR TITLE
#14 - Fix graceful connection closing

### DIFF
--- a/lib/graceful-exit.js
+++ b/lib/graceful-exit.js
@@ -149,7 +149,19 @@ exports.middleware = function middleware (app) {
   return function checkIfExitingGracefully (req, res, next) {
     if (app.settings.graceful_exit === true) {
       // sorry keep-alive connections, but we need to part ways
-      req.connection.setTimeout(1);
+      // (after the received request is processed and the response sent if done
+      // prior to the suicideTimeout)
+
+      // 2019-09-10 - HH - Do not set the connection timeout as it will
+      // close the connection before the response is ready and it will not
+      // do so using the Connection: close response header but will instead
+      // simply close the socket.  Setting Connection: close will allow the 
+      // response to be sent and for the caller to be notified that the server
+      // has closed the connection.
+      // https://github.com/emostar/express-graceful-exit/issues/14
+      // Test application: https://github.com/huntharo/express-graceful-exit-test
+      // OLD: req.connection.setTimeout(1);
+      res.set('Connection', 'close');
     }
 
     next();


### PR DESCRIPTION
- WAS: closing connection after receiving a request but allowing that request to run to completion in most cases
- IS: closing connection with a Connection: close response header after finishing running the request, so long as it can be completed before suicideTimeout has expired
- Full details in #14