### PR TITLE
Upgrade underscore version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "underscore": "^1.4.4"
+    "underscore": "^1.12.1"
   }
 }


### PR DESCRIPTION
This PR upgrades the version of the `underscore` dependency from `^1.4.4` to `^1.12.1` to address its recently-discovered  [arbitrary code execution security vulnerability](https://snyk.io/vuln/SNYK-JS-UNDERSCORE-1080984).