### PR TITLE
Typings: fix compilation error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { Server } from 'net'
 import { Express, NextFunction, Request, RequestHandler, Response } from 'express'
 
-namespace GracefulExit {
+declare namespace GracefulExit {
   interface Configuration {
     errorDuringExit?: boolean
     performLastRequest?: boolean


### PR DESCRIPTION
```
index.d.ts:4:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

4 namespace GracefulExit {
```


fixes - https://github.com/emostar/express-graceful-exit/issues/24